### PR TITLE
Title: Fix SonarQube Issues in Application.java

### DIFF
--- a/src/main/java/com/example/Application.java
+++ b/src/main/java/com/example/Application.java
@@ -2,7 +2,7 @@ package com.example;
 
 import io.micronaut.runtime.Micronaut;
 
-public class Application {
+public class Application { private Application() {}
 
     public static void main(String[] args) {
         Micronaut.run(Application.class, args);


### PR DESCRIPTION
## Title: Fix SonarQube Issues in Application.java

### Description:
This PR addresses a major SonarQube issue identified in the `Application.java` file. The issue is related to the rule `java:S1118` which suggests adding a private constructor to hide the implicit public one.

### Changes:
1. Added a private constructor to the `Application` class in `src/main/java/com/example/Application.java` to prevent the creation of the default public constructor.

```diff
- public class Application {
+ public class Application { private Application() {}
    public static void main(String[] args) {
        Micronaut.run(Application.class, args);
    }
}
```

### Considerations:
The addition of the private constructor does not introduce any breaking changes as the `Application` class is not intended to be instantiated. However, any future requirements for instantiating the `Application` class will need to consider this change.

### SonarQube Issue Reference:
The SonarQube issue key for this problem is `AZkRXDGPgTo4hhRGifKX`. The severity of this issue is marked as `MAJOR`. You can find more details about this issue on the SonarQube dashboard.

### Checklist:
- [x] Identified the SonarQube issue
- [x] Made necessary changes to fix the issue
- [x] Checked for any potential breaking changes
- [x] Referenced the SonarQube issue in the PR
- [x] Used proper markdown formatting in the PR description

Please review the changes and provide your valuable feedback.